### PR TITLE
Add source preparation and solution reconstruction

### DIFF
--- a/block.h
+++ b/block.h
@@ -26,10 +26,10 @@
 #include "su3.h"
 #include "su3spinor.h"
 
-_Complex double * little_A;
-_Complex float * little_A32;
-_Complex double * little_A_eo;
-_Complex float * little_A_eo_32;
+extern _Complex double * little_A;
+extern _Complex float * little_A32;
+extern _Complex double * little_A_eo;
+extern _Complex float * little_A_eo_32;
 
 
 typedef struct {

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -48,12 +48,35 @@ void cplx_mul_acc(FT &r_out, FT &i_out, FT const &a, FT const &b, FT const &c, F
   i_out += a * d + b * c;
 }
 
+/**
+  Wrapper for the clover multiplication function.
+
+  The `struct` is needed in order to allow for partial template specialization in the `Clover`
+  parameter.
+
+  \tparam Clover Type of clover block to use, must be a type from Geometry such that there exists a
+  specialization for it.
+  */
 template <typename FT, int veclen, int soalen, bool compress12, typename Clover>
 struct InnerCloverProduct {
+  /**
+  Multiplies the clover term for a single lattice size to a spinor.
+
+  This function is intended to be used in a loop over all lattice sites. It is expected from the
+  caller to have figured out all the correct indices. There are template specializations for the two
+  different types of clover term that are used in QPhiX.
+
+  \param[out] out Output spinor block. It is assumed to be zeroed properly, the function will just
+  accumulate values into that output variable. Use \ref QPhiX::zeroSpinor for that.
+  \param[in] in Input spinor block.
+  \param[in] clover Single clover block that contains the lattice site of the spinor.
+  \param[in] xi SIMD index for the arrays with length `soalen`, as in the spinors.
+  \param[in] veclen_idx SIMD index for the arrays with length `veclen`, as in the clover term.
+  */
   static void multiply(
       typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::FourSpinorBlock &out,
       typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::FourSpinorBlock const &in,
-      Clover const &clover);
+      Clover const &clover, int const xi, int const veclen_idx);
 };
 
 template <typename FT, int veclen, int soalen, bool compress12>

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -377,6 +377,24 @@ class FourSpinorCBWrapper {
   FourSpinorBlock *const spinor;
 };
 
+/**
+  Abstract base class for all single-flavor Dslash variants.
+
+  There are four Dslash operators which are implemented in QPhiX:
+
+  - Wilson
+  - Wilson clover
+  - Wilson twisted mass
+  - Wilson clover with twisted mass
+
+  Each of these has a the actual Dslash operation and a so-called “achimbdpsi” operation. These act
+  on four-spinors given a gauge field. This base class provides a uniform interface to all four
+  kinds.
+
+  This code should eventually be migrated into the QPhiX repository. Currently these classes are
+  mere delegators. In the QPhiX repository, the actual classes there should be used as concrete
+  classes.
+  */
 template <typename FT, int veclen, int soalen, bool compress12>
 class Dslash {
  public:
@@ -645,7 +663,18 @@ class WilsonClovDslash : public Dslash<FT, veclen, soalen, compress12> {
   double const mass_factor_alpha;
   double const mass_factor_beta;
 
+  /**
+    Reference to the clover term.
+
+    This class has to provide a `dslash` and `achimbdpsi` member function with the prescribed
+    argument list which does not contain the clover term. The user of these classes should not have
+    to differentiate between non-clover and clover variants. In order to provide the function
+    signature, the clover term is a member. This means that the user has to construct a new operator
+    each time the clover time has changed.
+    */
   CloverBlock *const clover;
+
+  /// See \ref clover.
   CloverBlock *const inv_clover;
 };
 

--- a/qphix_base_classes.hpp
+++ b/qphix_base_classes.hpp
@@ -39,11 +39,6 @@ int constexpr cb_even = 1;
 int constexpr cb_odd = 0;
 }
 
-template <typename FT, int veclen, int soalen, bool compress12>
-size_t get_num_blocks(::QPhiX::Geometry<FT, veclen, soalen, compress12> &geom) {
-  return geom.Nt() * geom.Nz() * geom.Ny() * geom.nVecs();
-}
-
 /**
   Complex multiplication accumulate.
 
@@ -343,39 +338,6 @@ void full_clover_product(
     }
   }
 }
-
-/**
-  RAII container for checkerboarded four spinors.
-
-  The four spinors are C-style arrays with no length information and most
-  importantly no cleanup. This wrapper enables automatic cleanup using the
-  QPhiX::Geometry object.
-
-  Perhaps it would be even better to use `std::vector` with a custom allocator
-  for this structure.
-  */
-template <typename FT, int veclen, int soalen, bool compress12>
-class FourSpinorCBWrapper {
- public:
-  typedef
-      typename ::QPhiX::Geometry<FT, veclen, soalen, compress12>::FourSpinorBlock FourSpinorBlock;
-
-  FourSpinorCBWrapper(::QPhiX::Geometry<FT, veclen, soalen, compress12> &geom_)
-      : geom(geom_), spinor(geom.allocCBFourSpinor()) {}
-
-  ~FourSpinorCBWrapper() { geom.free(spinor); }
-
-  FourSpinorBlock const *data() const { return spinor; }
-  FourSpinorBlock *data() { return spinor; }
-
-  size_t num_blocks() const { return get_num_blocks(geom); }
-
-  FourSpinorBlock &operator[](size_t i) { return spinor[i]; }
-
- private:
-  ::QPhiX::Geometry<FT, veclen, soalen, compress12> &geom;
-  FourSpinorBlock *const spinor;
-};
 
 /**
   Abstract base class for all single-flavor Dslash variants.

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -88,13 +88,6 @@ extern "C" {
 
 #include <vector>
 
-// XXX Can we please not do that? tmLQCD and QPhiX are libraries of the same domain and define the
-// same stuff with slightly different names. One has to be an expert in both libraries to know where
-// a symbol comes from. Martin would prefer to have `QPhiX::` in front of the QPhiX types and
-// functions.
-using namespace std;
-using namespace QPhiX;
-
 // XXX The following block of code also occurs many times in QPhiX. It seems appropriate to put that
 // into the QPhiX library.
 #ifndef QPHIX_SOALEN
@@ -167,7 +160,7 @@ struct rsdTarget {
 };
 
 template <>
-const double rsdTarget<half>::value = 1.0e-4;
+const double rsdTarget<QPhiX::half>::value = 1.0e-4;
 
 template <>
 const double rsdTarget<float>::value = 1.0e-7;
@@ -237,7 +230,8 @@ void _endQphix() {}
 
 // Reorder the tmLQCD clover field to a Wilson QPhiX clover field
 template <typename FT, int VECLEN, int SOALEN, bool compress12>
-void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT *qphix_clover) {
+void reorder_clover_to_QPhiX(QPhiX::Geometry<FT, VECLEN, SOALEN, compress12> &geom,
+                             FT *qphix_clover) {
   const double startTime = gettime();
 
   std::vector<uint64_t> const lookup_table{
@@ -311,13 +305,13 @@ void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT 
 
   const double endTime = gettime();
   const double diffTime = endTime - startTime;
-  masterPrintf("  time spent in reorder_clover_to_QPhiX: %f secs\n", diffTime);
+  QPhiX::masterPrintf("  time spent in reorder_clover_to_QPhiX: %f secs\n", diffTime);
 }
 
 // Reorder the tmLQCD gauge field to a cb0 and a cb1 QPhiX gauge field
 template <typename FT, int VECLEN, int SOALEN, bool compress12>
-void reorder_gauge_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT *qphix_gauge_cb0,
-                            FT *qphix_gauge_cb1) {
+void reorder_gauge_to_QPhiX(QPhiX::Geometry<FT, VECLEN, SOALEN, compress12> &geom,
+                            FT *qphix_gauge_cb0, FT *qphix_gauge_cb1) {
   const double startTime = gettime();
 
   // Number of elements in spin, color & complex
@@ -409,13 +403,13 @@ void reorder_gauge_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT *
 
   const double endTime = gettime();
   const double diffTime = endTime - startTime;
-  masterPrintf("  time spent in reorder_gauge_to_QPhiX: %f secs\n", diffTime);
+  QPhiX::masterPrintf("  time spent in reorder_gauge_to_QPhiX: %f secs\n", diffTime);
 }
 
 // Reorder tmLQCD spinor to a cb0 and cb1 QPhiX spinor
 template <typename FT, int VECLEN, int SOALEN, bool compress12>
-void reorder_spinor_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, double const *tm_spinor,
-                             FT *qphix_spinor_cb0, FT *qphix_spinor_cb1) {
+void reorder_spinor_to_QPhiX(QPhiX::Geometry<FT, VECLEN, SOALEN, compress12> &geom,
+                             double const *tm_spinor, FT *qphix_spinor_cb0, FT *qphix_spinor_cb1) {
   const double startTime = gettime();
 
   // Number of elements in spin, color & complex
@@ -475,14 +469,14 @@ void reorder_spinor_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, dou
 
   const double endTime = gettime();
   const double diffTime = endTime - startTime;
-  masterPrintf("  time spent in reorder_spinor_to_QPhiX: %f secs\n", diffTime);
+  QPhiX::masterPrintf("  time spent in reorder_spinor_to_QPhiX: %f secs\n", diffTime);
 }
 
 // Reorder a cb0 and cb1 QPhiX spinor to a tmLQCD spinor
 template <typename FT, int VECLEN, int SOALEN, bool compress12>
-void reorder_spinor_from_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, double *tm_spinor,
-                               FT const *qphix_spinor_cb0, FT const *qphix_spinor_cb1,
-                               double normFac = 1.0) {
+void reorder_spinor_from_QPhiX(QPhiX::Geometry<FT, VECLEN, SOALEN, compress12> &geom,
+                               double *tm_spinor, FT const *qphix_spinor_cb0,
+                               FT const *qphix_spinor_cb1, double normFac = 1.0) {
   const double startTime = gettime();
 
   // Number of elements in spin, color & complex
@@ -542,15 +536,15 @@ void reorder_spinor_from_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, d
 
   const double endTime = gettime();
   const double diffTime = endTime - startTime;
-  masterPrintf("  time spent in reorder_spinor_from_QPhiX: %f secs\n", diffTime);
+  QPhiX::masterPrintf("  time spent in reorder_spinor_from_QPhiX: %f secs\n", diffTime);
 }
 
 // Apply the Dslash to a full tmlQCD spinor and return a full tmlQCD spinor
 template <typename FT, int V, int S, bool compress>
 void D_psi(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
 
-  typedef typename Geometry<FT, V, S, compress>::SU3MatrixBlock QGauge;
-  typedef typename Geometry<FT, V, S, compress>::FourSpinorBlock QSpinor;
+  typedef typename QPhiX::Geometry<FT, V, S, compress>::SU3MatrixBlock QGauge;
+  typedef typename QPhiX::Geometry<FT, V, S, compress>::FourSpinorBlock QSpinor;
 
   /************************
    *                      *
@@ -561,33 +555,34 @@ void D_psi(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
    *                      *
   ************************/
 
-  masterPrintf("VECLEN=%d SOALEN=%d\n", V, S);
-  masterPrintf("# Declared QMP Topology: %d %d %d %d\n", qmp_geom[0], qmp_geom[1], qmp_geom[2],
+  QPhiX::masterPrintf("VECLEN=%d SOALEN=%d\n", V, S);
+  QPhiX::masterPrintf("# Declared QMP Topology: %d %d %d %d\n", qmp_geom[0], qmp_geom[1], qmp_geom[2],
                qmp_geom[3]);
-  masterPrintf("Global Lattice Size = ");
+  QPhiX::masterPrintf("Global Lattice Size = ");
   for (int mu = 0; mu < 4; mu++) {
-    masterPrintf(" %d", lattSize[mu]);
+    QPhiX::masterPrintf(" %d", lattSize[mu]);
   }
-  masterPrintf("\n");
-  masterPrintf("Local Lattice Size = ");
+  QPhiX::masterPrintf("\n");
+  QPhiX::masterPrintf("Local Lattice Size = ");
   for (int mu = 0; mu < 4; mu++) {
-    masterPrintf(" %d", subLattSize[mu]);
+    QPhiX::masterPrintf(" %d", subLattSize[mu]);
   }
-  masterPrintf("\n");
-  masterPrintf("Block Sizes: By= %d Bz=%d\n", By, Bz);
-  masterPrintf("Cores = %d\n", NCores);
-  masterPrintf("SMT Grid: Sy=%d Sz=%d\n", Sy, Sz);
-  masterPrintf("Pad Factors: PadXY=%d PadXYZ=%d\n", PadXY, PadXYZ);
-  masterPrintf("Threads_per_core = %d\n", N_simt);
-  masterPrintf("MinCt = %d\n", MinCt);
-  masterPrintf("Initializing QPhiX Dslash\n");
+  QPhiX::masterPrintf("\n");
+  QPhiX::masterPrintf("Block Sizes: By= %d Bz=%d\n", By, Bz);
+  QPhiX::masterPrintf("Cores = %d\n", NCores);
+  QPhiX::masterPrintf("SMT Grid: Sy=%d Sz=%d\n", Sy, Sz);
+  QPhiX::masterPrintf("Pad Factors: PadXY=%d PadXYZ=%d\n", PadXY, PadXYZ);
+  QPhiX::masterPrintf("Threads_per_core = %d\n", N_simt);
+  QPhiX::masterPrintf("MinCt = %d\n", MinCt);
+  QPhiX::masterPrintf("Initializing QPhiX Dslash\n");
 
   // Create Dslash Class
   double t_boundary = (FT)(1);
   double coeff_s = (FT)(1);
   double coeff_t = (FT)(1);
 
-  Geometry<FT, V, S, compress> geom(subLattSize, By, Bz, NCores, Sy, Sz, PadXY, PadXYZ, MinCt);
+  QPhiX::Geometry<FT, V, S, compress> geom(subLattSize, By, Bz, NCores, Sy, Sz, PadXY, PadXYZ,
+                                           MinCt);
 
   // tmLQCD only stores kappa, QPhiX uses the mass. Convert here.
   double const mass = 1 / (2.0 * g_kappa) - 4;
@@ -595,7 +590,8 @@ void D_psi(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
 #if 0 // Change the operator to use here.
   tmlqcd::WilsonDslash<FT, V, S, compress> concrete_dslash(&geom, t_boundary, coeff_s, coeff_t, mass);
 #else
-  tmlqcd::WilsonTMDslash<FT, V, S, compress> concrete_dslash(&geom, t_boundary, coeff_s, coeff_t, mass, 1.21);
+  tmlqcd::WilsonTMDslash<FT, V, S, compress> concrete_dslash(&geom, t_boundary, coeff_s, coeff_t,
+                                                             mass, 1.21);
 #endif
 
   tmlqcd::Dslash<FT, V, S, compress> &polymorphic_dslash = concrete_dslash;
@@ -674,7 +670,7 @@ void D_psi(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
                             reinterpret_cast<FT*>(qphix_out[1]),
                             (1. * g_kappa));
 
-  masterPrintf("Cleaning up\n");
+  QPhiX::masterPrintf("Cleaning up\n");
 
   geom.free(packed_gauge_cb0);
   geom.free(packed_gauge_cb1);
@@ -698,8 +694,8 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
     solver_params_t solver_params,
     const CompressionType compression) {
 
-  typedef typename Geometry<FT, V, S, compress>::SU3MatrixBlock QGauge;
-  typedef typename Geometry<FT, V, S, compress>::FourSpinorBlock QSpinor;
+  typedef typename QPhiX::Geometry<FT, V, S, compress>::SU3MatrixBlock QGauge;
+  typedef typename QPhiX::Geometry<FT, V, S, compress>::FourSpinorBlock QSpinor;
 
   /************************
    *                      *
@@ -709,24 +705,25 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
 
   // _initQphix should have been called at this point
 
-  masterPrintf("# VECLEN = %d, SOALEN = %d\n", V, S);
-  masterPrintf("# Declared QMP Topology: %d %d %d %d\n",
+  QPhiX::masterPrintf("# VECLEN = %d, SOALEN = %d\n", V, S);
+  QPhiX::masterPrintf("# Declared QMP Topology: %d %d %d %d\n",
       qmp_geom[0], qmp_geom[1], qmp_geom[2], qmp_geom[3]);
-  masterPrintf("# Global Lattice Size = %d %d %d %d\n",
+  QPhiX::masterPrintf("# Global Lattice Size = %d %d %d %d\n",
       lattSize[0], lattSize[1], lattSize[2], lattSize[3]);
-  masterPrintf("#  Local Lattice Size = %d %d %d %d\n",
+  QPhiX::masterPrintf("#  Local Lattice Size = %d %d %d %d\n",
       subLattSize[0], subLattSize[1], subLattSize[2], subLattSize[3]);
-  masterPrintf("# Block Sizes: By = %d, Bz = %d\n", By, Bz);
-  masterPrintf("# Cores = %d\n", NCores);
-  masterPrintf("# SMT Grid: Sy = %d, Sz = %d\n", Sy, Sz);
-  masterPrintf("# Pad Factors: PadXY = %d, PadXYZ = %d\n", PadXY, PadXYZ);
-  masterPrintf("# Threads_per_core = %d\n", N_simt);
-  masterPrintf("# MinCt = %d\n", MinCt);
+  QPhiX::masterPrintf("# Block Sizes: By = %d, Bz = %d\n", By, Bz);
+  QPhiX::masterPrintf("# Cores = %d\n", NCores);
+  QPhiX::masterPrintf("# SMT Grid: Sy = %d, Sz = %d\n", Sy, Sz);
+  QPhiX::masterPrintf("# Pad Factors: PadXY = %d, PadXYZ = %d\n", PadXY, PadXYZ);
+  QPhiX::masterPrintf("# Threads_per_core = %d\n", N_simt);
+  QPhiX::masterPrintf("# MinCt = %d\n", MinCt);
 
   // Create a Geometry Class
-  masterPrintf("# Initializing QPhiX Geometry...\n");
-  Geometry<FT, V, S, compress> geom(subLattSize, By, Bz, NCores, Sy, Sz, PadXY, PadXYZ, MinCt);
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# Initializing QPhiX Geometry...\n");
+  QPhiX::Geometry<FT, V, S, compress> geom(subLattSize, By, Bz, NCores, Sy, Sz, PadXY, PadXYZ,
+                                           MinCt);
+  QPhiX::masterPrintf("# ...done.\n");
 
   /************************
    *                      *
@@ -734,7 +731,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                      *
   ************************/
 
-  masterPrintf("# Allocating and preparing gauge fields...\n");
+  QPhiX::masterPrintf("# Allocating and preparing gauge fields...\n");
 
   // Allocate data for the gauge fields
   QGauge *u_packed[2];
@@ -748,7 +745,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
                          reinterpret_cast<FT*>(u_packed[0]),
                          reinterpret_cast<FT*>(u_packed[1]));
 
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   /************************
    *                      *
@@ -756,7 +753,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                      *
   ************************/
 
-  masterPrintf("# Allocating fermion fields...\n");
+  QPhiX::masterPrintf("# Allocating fermion fields...\n");
 
   // Allocate data for the even/odd (checkerboarded) QPhiX in/out spinors
   QSpinor *packed_spinor_in_cb0 = (QSpinor *)geom.allocCBFourSpinor();
@@ -782,7 +779,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
   init_solver_field(&solver_fields, VOLUMEPLUSRAND, nr_solver_fields);
   spinor *tmlqcd_full_buffer = solver_fields[0];
 
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   /************************************************
    *                                              *
@@ -800,69 +797,69 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
 
   // Create a Wilson Dslash for source preparation
   // and solution reconstruction
-  masterPrintf("# Creating plain QPhiX Wilson Dslash (for preparation)...\n");
+  QPhiX::masterPrintf("# Creating plain QPhiX Wilson Dslash (for preparation)...\n");
   QPhiX::Dslash<FT, V, S, compress>* WilsonDslash =
     new QPhiX::Dslash<FT, V, S, compress>(&geom, t_boundary, coeff_s, coeff_t);
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   // Create a Dslash & an even-odd preconditioned Fermion Matrix object,
   // depending on the chosen fermion action
   tmlqcd::Dslash<FT, V, S, compress>* DslashQPhiX;
-  EvenOddLinearOperator<FT, V, S, compress>* FermionMatrixQPhiX;
+  QPhiX::EvenOddLinearOperator<FT, V, S, compress> *FermionMatrixQPhiX;
   if( g_mu != 0.0 && g_c_sw > 0.0 ) { // TWISTED-MASS-CLOVER
     // TODO: Implement me!
-    masterPrintf("# TWISTED-MASS-CLOVER CASE NOT YET IMPLEMENTED!\n");
-    masterPrintf(" Aborting...\n");
+    QPhiX::masterPrintf("# TWISTED-MASS-CLOVER CASE NOT YET IMPLEMENTED!\n");
+    QPhiX::masterPrintf(" Aborting...\n");
     abort();
   } else if( g_mu != 0.0 ) { // TWISTED-MASS
-    masterPrintf("# Creating QPhiX Twisted Mass Wilson Dslash...\n");
+    QPhiX::masterPrintf("# Creating QPhiX Twisted Mass Wilson Dslash...\n");
     const double TwistedMass = - g_mu / (2.0 * g_kappa);
     DslashQPhiX = new tmlqcd::WilsonTMDslash<FT, V, S, compress>
       (&geom, t_boundary, coeff_s, coeff_t, mass, TwistedMass);
-    masterPrintf("# ...done.\n");
+    QPhiX::masterPrintf("# ...done.\n");
 
-    masterPrintf("# Creating QPhiX Twisted Mass Wilson Fermion Matrix...\n");
-    FermionMatrixQPhiX = new EvenOddTMWilsonOperator<FT, V, S, compress>
+    QPhiX::masterPrintf("# Creating QPhiX Twisted Mass Wilson Fermion Matrix...\n");
+    FermionMatrixQPhiX = new QPhiX::EvenOddTMWilsonOperator<FT, V, S, compress>
       (mass, TwistedMass, u_packed, &geom, t_boundary, coeff_s, coeff_t);
-    masterPrintf("# ...done.\n");
+    QPhiX::masterPrintf("# ...done.\n");
   } else if( g_c_sw > 0.0 ) { // WILSON CLOVER
     // TODO: Implement me!
-    masterPrintf("# WILSON CLOVER CASE NOT YET IMPLEMENTED!\n");
-    masterPrintf(" Aborting...\n");
+    QPhiX::masterPrintf("# WILSON CLOVER CASE NOT YET IMPLEMENTED!\n");
+    QPhiX::masterPrintf(" Aborting...\n");
     abort();
   } else { // WILSON
-    masterPrintf("# Creating QPhiX Wilson Dslash...\n");
+    QPhiX::masterPrintf("# Creating QPhiX Wilson Dslash...\n");
     DslashQPhiX = new tmlqcd::WilsonDslash<FT, V, S, compress>(&geom, t_boundary, coeff_s, coeff_t, mass);
-    masterPrintf("# ...done.\n");
+    QPhiX::masterPrintf("# ...done.\n");
 
-    masterPrintf("# Creating QPhiX Wilson Fermion Matrix...\n");
-    FermionMatrixQPhiX = new EvenOddWilsonOperator<FT, V, S, compress>
+    QPhiX::masterPrintf("# Creating QPhiX Wilson Fermion Matrix...\n");
+    FermionMatrixQPhiX = new QPhiX::EvenOddWilsonOperator<FT, V, S, compress>
       (mass, u_packed, &geom, t_boundary, coeff_s, coeff_t);
-    masterPrintf("# ...done.\n");
+    QPhiX::masterPrintf("# ...done.\n");
   }
 
   // Create a Linear Solver Object
-  AbstractSolver<FT, V, S, compress>* SolverQPhiX;
+  QPhiX::AbstractSolver<FT, V, S, compress>* SolverQPhiX;
   if(solver_flag == CG) {
-    masterPrintf("# Creating CG Solver...\n");
-    SolverQPhiX = new InvCG<FT, V, S, compress> (*FermionMatrixQPhiX, max_iter);
+    QPhiX::masterPrintf("# Creating CG Solver...\n");
+    SolverQPhiX = new QPhiX::InvCG<FT, V, S, compress> (*FermionMatrixQPhiX, max_iter);
   } else if(solver_flag == BICGSTAB) {
-    masterPrintf("# Creating BiCGStab Solver...\n");
-    SolverQPhiX = new InvBiCGStab<FT, V, S, compress> (*FermionMatrixQPhiX, max_iter);
+    QPhiX::masterPrintf("# Creating BiCGStab Solver...\n");
+    SolverQPhiX = new QPhiX::InvBiCGStab<FT, V, S, compress> (*FermionMatrixQPhiX, max_iter);
   } else {
     // TODO: Implement multi-shift CG, Richardson multi-precision
-    masterPrintf(" Solver not yet supported by QPhiX!\n");
-    masterPrintf(" Aborting...\n");
+    QPhiX::masterPrintf(" Solver not yet supported by QPhiX!\n");
+    QPhiX::masterPrintf(" Aborting...\n");
     abort();
   }
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   // Set number of BLAS threads by hand.
   // In case some implements the tune routines in QPhiX
   // this may be updated...
-  masterPrintf("# Setting number of BLAS threads...\n");
+  QPhiX::masterPrintf("# Setting number of BLAS threads...\n");
   const int n_blas_simt = N_simt;
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   /************************
    *                      *
@@ -870,7 +867,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                      *
   ************************/
 
-  masterPrintf("# Preparing odd source...\n");
+  QPhiX::masterPrintf("# Preparing odd source...\n");
 
   // 1. Reorder input spinor from tmLQCD to QPhiX:
   // a) Merge the even & odd tmlQCD input spinors to a full spinor
@@ -904,7 +901,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
                        0);                // target cb == odd
   QPhiX::aypx(0.5, qphix_in[0], qphix_in_prepared, geom, n_blas_simt);
 
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   /************************
    *                      *
@@ -912,7 +909,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                      *
   ************************/
 
-  masterPrintf("# Calling the solver...\n");
+  QPhiX::masterPrintf("# Calling the solver...\n");
 
   // Set variables need for solve
   bool verbose = true;
@@ -952,8 +949,8 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
 
   uint64_t num_cb_sites = lattSize[0]/2 * lattSize[1] * lattSize[2] * lattSize[3];
   uint64_t total_flops = (site_flops + (72 + 2*1320) * mv_apps) * num_cb_sites;
-  masterPrintf("# Solver Time = %g sec\n", (end-start));
-  masterPrintf("# Performance in GFLOPS = %g\n", 1.0e-9 * total_flops / (end-start));
+  QPhiX::masterPrintf("# Solver Time = %g sec\n", (end-start));
+  QPhiX::masterPrintf("# Performance in GFLOPS = %g\n", 1.0e-9 * total_flops / (end-start));
 
   /**************************
    *                        *
@@ -961,7 +958,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                        *
   **************************/
 
-  masterPrintf("# Reconstruction even solution...\n");
+  QPhiX::masterPrintf("# Reconstruction even solution...\n");
 
   // 1. Reconstruct the even (cb1) solution
   //
@@ -994,7 +991,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
                       tmlqcd_odd_out,      // new odd spinor
                       tmlqcd_full_buffer); // full spinor
 
-  masterPrintf("# ...done.\n");
+  QPhiX::masterPrintf("# ...done.\n");
 
   /******************
    *                *
@@ -1002,7 +999,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
    *                *
   ******************/
 
-  masterPrintf("# Cleaning up\n");
+  QPhiX::masterPrintf("# Cleaning up\n");
 
   geom.free(packed_gauge_cb0);
   geom.free(packed_gauge_cb1);
@@ -1017,7 +1014,7 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
   // FIXME: This should be called properly somewhere else
   _endQphix();
 
-  masterPrintf("# ...done.\n\n");
+  QPhiX::masterPrintf("# ...done.\n\n");
 
   return niters;
 }
@@ -1027,11 +1024,11 @@ int invert_eo_qphix_helper(spinor * const tmlqcd_even_out,
 void D_psi_qphix(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
   if (qphix_precision == QPHIX_DOUBLE_PREC) {
     if (QPHIX_SOALEN > VECLEN_DP) {
-      masterPrintf("SOALEN=%d is greater than the double prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the double prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_DP);
       abort();
     }
-    masterPrintf("TIMING IN DOUBLE PRECISION \n");
+    QPhiX::masterPrintf("TIMING IN DOUBLE PRECISION \n");
     if (compress12) {
       D_psi<double, VECLEN_DP, QPHIX_SOALEN, true>(tmlqcd_out, tmlqcd_in);
     } else {
@@ -1039,11 +1036,11 @@ void D_psi_qphix(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
     }
   } else if (qphix_precision == QPHIX_FLOAT_PREC) {
     if (QPHIX_SOALEN > VECLEN_SP) {
-      masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_SP);
       abort();
     }
-    masterPrintf("TIMING IN SINGLE PRECISION \n");
+    QPhiX::masterPrintf("TIMING IN SINGLE PRECISION \n");
     if (compress12) {
       D_psi<float, VECLEN_SP, QPHIX_SOALEN, true>(tmlqcd_out, tmlqcd_in);
     } else {
@@ -1053,15 +1050,15 @@ void D_psi_qphix(spinor* tmlqcd_out, const spinor* tmlqcd_in) {
 #if defined(QPHIX_MIC_SOURCE)
   else if (qphix_precision == QPHIX_HALF_PREC) {
     if (QPHIX_SOALEN > VECLEN_HP) {
-      masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_SP);
       abort();
     }
-    masterPrintf("TIMING IN HALF PRECISION \n");
+    QPhiX::masterPrintf("TIMING IN HALF PRECISION \n");
     if (compress12) {
-      D_psi<half, VECLEN_HP, QPHIX_SOALEN, true>(tmlqcd_out, tmlqcd_in);
+      D_psi<QPhiX::half, VECLEN_HP, QPHIX_SOALEN, true>(tmlqcd_out, tmlqcd_in);
     } else {
-      D_psi<half, VECLEN_HP, QPHIX_SOALEN, false>(tmlqcd_out, tmlqcd_in);
+      D_psi<QPhiX::half, VECLEN_HP, QPHIX_SOALEN, false>(tmlqcd_out, tmlqcd_in);
     }
   }
 #endif
@@ -1085,12 +1082,12 @@ int invert_eo_qphix(spinor * const Even_new,
 
   if (precision < rsdTarget<double>::value) {
     if (QPHIX_SOALEN > VECLEN_DP) {
-      masterPrintf("SOALEN=%d is greater than the double prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the double prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_DP);
       abort();
     }
-    masterPrintf("# INITIALIZING QPHIX SOLVER\n");
-    masterPrintf("# USING DOUBLE PRECISION\n");
+    QPhiX::masterPrintf("# INITIALIZING QPHIX SOLVER\n");
+    QPhiX::masterPrintf("# USING DOUBLE PRECISION\n");
     _initQphix(0, nullptr, qphix_input_By, qphix_input_Bz, qphix_input_NCores,
            qphix_input_Sy, qphix_input_Sz,
            qphix_input_PadXY, qphix_input_PadXYZ, qphix_input_MinCt,
@@ -1127,12 +1124,12 @@ int invert_eo_qphix(spinor * const Even_new,
   } else {
 #endif
     if (QPHIX_SOALEN > VECLEN_SP) {
-      masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_SP);
       abort();
     }
-    masterPrintf("# INITIALIZING QPHIX SOLVER\n");
-    masterPrintf("# USING SINGLE PRECISION\n");
+    QPhiX::masterPrintf("# INITIALIZING QPHIX SOLVER\n");
+    QPhiX::masterPrintf("# USING SINGLE PRECISION\n");
     _initQphix(0, nullptr, qphix_input_By, qphix_input_Bz, qphix_input_NCores,
            qphix_input_Sy, qphix_input_Sz,
            qphix_input_PadXY, qphix_input_PadXYZ, qphix_input_MinCt,
@@ -1165,21 +1162,21 @@ int invert_eo_qphix(spinor * const Even_new,
     }
   }
 #if defined(QPHIX_MIC_SOURCE)
-  else if (precision < rsdTarget<half>::value) {
+  else if (precision < rsdTarget<QPhiX::half>::value) {
     if (QPHIX_SOALEN > VECLEN_HP) {
-      masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
+      QPhiX::masterPrintf("SOALEN=%d is greater than the single prec VECLEN=%d\n", QPHIX_SOALEN,
                    VECLEN_SP);
       abort();
     }
-    masterPrintf("# INITIALIZING QPHIX SOLVER\n");
-    masterPrintf("# USING HALF PRECISION\n");
+    QPhiX::masterPrintf("# INITIALIZING QPHIX SOLVER\n");
+    QPhiX::masterPrintf("# USING HALF PRECISION\n");
     _initQphix(0, nullptr, qphix_input_By, qphix_input_Bz, qphix_input_NCores,
            qphix_input_Sy, qphix_input_Sz,
            qphix_input_PadXY, qphix_input_PadXYZ, qphix_input_MinCt,
            compression, QPHIX_HALF_PREC);
     
     if (compress12) {
-      return invert_eo_qphix_helper<half, VECLEN_SP, QPHIX_SOALEN, true>
+      return invert_eo_qphix_helper<QPhiX::half, VECLEN_SP, QPHIX_SOALEN, true>
         (Even_new,
          Odd_new,
          Even,
@@ -1191,7 +1188,7 @@ int invert_eo_qphix(spinor * const Even_new,
          solver_params,
          compression);
     } else {
-      return invert_eo_qphix_helper<half, VECLEN_SP, QPHIX_SOALEN, false>
+      return invert_eo_qphix_helper<QPhiX::half, VECLEN_SP, QPHIX_SOALEN, false>
         (Even_new,
          Odd_new,
          Even,
@@ -1211,11 +1208,11 @@ int invert_eo_qphix(spinor * const Even_new,
 
 void checkQphixInputParameters() {
   if( qphix_input_By == 0 || qphix_input_Bz == 0){
-    masterPrintf("QPHIX Error: By and Bz may not be 0 ! Aborting.\n");
+    QPhiX::masterPrintf("QPHIX Error: By and Bz may not be 0 ! Aborting.\n");
     abort();
   }
   if( qphix_input_NCores * qphix_input_Sy * qphix_input_Sz != omp_num_threads ){
-    masterPrintf("QPHIX Error: NCores * Sy * Sz != ompnumthreads ! Aborting.\n");
+    QPhiX::masterPrintf("QPHIX Error: NCores * Sy * Sz != ompnumthreads ! Aborting.\n");
     abort();
   }
 } 

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -302,7 +302,7 @@ void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT 
           const uint64_t tm_base = tm_idx * 3 * 2 * Nc * Nc * Nz;
 
           // FIXME Is there any better way to do that?
-          for (uint64_t lt_idx = 0; lt_idx < lookup_table.size(); ++lt_index) {
+          for (uint64_t lt_idx = 0; lt_idx < lookup_table.size(); ++lt_idx) {
             out[qphix_base + lt_idx * VECLEN + x_internal] =
                 alpha * in[tm_base + lookup_table[lt_idx]];
           }

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -18,6 +18,12 @@
  * along with tmLQCD.  If not, see <http://www.gnu.org/licenses/>.
  *
  ***********************************************************************/
+
+// XXX The following comment block seems be mostly redundant. The “Last changes” can be inferred
+// from git, and the externally accessible functions should be listed in the header files. Functions
+// starting with an underscore are often meant to be private (because the C language lacks
+// encapsulation …), so it seems strange that those functions are declared as the global ones.
+
 /***********************************************************************
 *
 * File qphix_interface.c
@@ -82,9 +88,15 @@ extern "C" {
 
 #include <vector>
 
+// XXX Can we please not do that? tmLQCD and QPhiX are libraries of the same domain and define the
+// same stuff with slightly different names. One has to be an expert in both libraries to know where
+// a symbol comes from. Martin would prefer to have `QPhiX::` in front of the QPhiX types and
+// functions.
 using namespace std;
 using namespace QPhiX;
 
+// XXX The following block of code also occurs many times in QPhiX. It seems appropriate to put that
+// into the QPhiX library.
 #ifndef QPHIX_SOALEN
 #error QPHIX_SOALEN must be defined. Check your qphix/qphix_config.h and qphix/qphix_config_internal.h !
 #endif
@@ -265,6 +277,10 @@ void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT 
         for (uint64_t z = 0; z < LZ; z++) {
 
           // Only copy the odd-odd elements of the clover term
+          // XXX This looks like `0` is `even`. In other parts of the QPhiX code, it seems like `1`
+          // is `even`. Either way, there is a magic number here which should be refactored into a
+          // global constant, probably best an enum. Then also this should be a function like
+          // `is_even` or `is_odd` to make the code more readable and less error prone.
           if ((t + x + y + z) & 1 == 0) continue;
 
           const uint64_t tm_idx = Index(t, x, y, z);

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -80,6 +80,8 @@ extern "C" {
 #include <qphix/wilson.h>
 #include <qphix/twisted_mass.h>
 
+#include <vector>
+
 using namespace std;
 using namespace QPhiX;
 
@@ -226,6 +228,16 @@ template <typename FT, int VECLEN, int SOALEN, bool compress12>
 void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT *qphix_clover) {
   const double startTime = gettime();
 
+  std::vector<uint64_t> const lookup_table{
+      0,  8,  16, 72, 80, 88,  2,  3,  4,  5,  36, 37, 38, 39, 40, 41, 10,  11,
+      42, 43, 44, 45, 46, 47,  48, 49, 50, 51, 52, 53, 74, 75, 76, 77, 82,  83,
+      18, 26, 34, 90, 98, 106, 20, 21, 22, 23, 54, 55, 56, 57, 58, 59, 28,  29,
+      60, 61, 62, 63, 64, 65,  66, 67, 68, 69, 70, 71, 92, 93, 94, 95, 100, 101};
+
+  assert(lookup_table.size() == 72 &&
+         "Number of elements in the lookup table needs to exactly match the number of elements in "
+         "the clover data structure.");
+
   // Need to rescale for QPhiX by alpha
   const double alpha = 1.0 / ( 2.0 * g_kappa );
 
@@ -273,81 +285,11 @@ void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT 
           const uint64_t qphix_base = qphix_idx * VECLEN * 2 * ( 6 + 15 * Nz );
           const uint64_t tm_base = tm_idx * 3 * 2 * Nc * Nc * Nz;
 
-          // FIXME:
-          // Is there any better way to do that?
-          // Use at least a lookup table
-          out[qphix_base +  0*VECLEN + x_internal] = alpha * in[tm_base +   0];
-          out[qphix_base +  1*VECLEN + x_internal] = alpha * in[tm_base +   8];
-          out[qphix_base +  2*VECLEN + x_internal] = alpha * in[tm_base +  16];
-          out[qphix_base +  3*VECLEN + x_internal] = alpha * in[tm_base +  72];
-          out[qphix_base +  4*VECLEN + x_internal] = alpha * in[tm_base +  80];
-          out[qphix_base +  5*VECLEN + x_internal] = alpha * in[tm_base +  88];
-          out[qphix_base +  6*VECLEN + x_internal] = alpha * in[tm_base +   2];
-          out[qphix_base +  7*VECLEN + x_internal] = alpha * in[tm_base +   3];
-          out[qphix_base +  8*VECLEN + x_internal] = alpha * in[tm_base +   4];
-          out[qphix_base +  9*VECLEN + x_internal] = alpha * in[tm_base +   5];
-          out[qphix_base + 10*VECLEN + x_internal] = alpha * in[tm_base +  36];
-          out[qphix_base + 11*VECLEN + x_internal] = alpha * in[tm_base +  37];
-          out[qphix_base + 12*VECLEN + x_internal] = alpha * in[tm_base +  38];
-          out[qphix_base + 13*VECLEN + x_internal] = alpha * in[tm_base +  39];
-          out[qphix_base + 14*VECLEN + x_internal] = alpha * in[tm_base +  40];
-          out[qphix_base + 15*VECLEN + x_internal] = alpha * in[tm_base +  41];
-          out[qphix_base + 16*VECLEN + x_internal] = alpha * in[tm_base +  10];
-          out[qphix_base + 17*VECLEN + x_internal] = alpha * in[tm_base +  11];
-          out[qphix_base + 18*VECLEN + x_internal] = alpha * in[tm_base +  42];
-          out[qphix_base + 19*VECLEN + x_internal] = alpha * in[tm_base +  43];
-          out[qphix_base + 20*VECLEN + x_internal] = alpha * in[tm_base +  44];
-          out[qphix_base + 21*VECLEN + x_internal] = alpha * in[tm_base +  45];
-          out[qphix_base + 22*VECLEN + x_internal] = alpha * in[tm_base +  46];
-          out[qphix_base + 23*VECLEN + x_internal] = alpha * in[tm_base +  47];
-          out[qphix_base + 24*VECLEN + x_internal] = alpha * in[tm_base +  48];
-          out[qphix_base + 25*VECLEN + x_internal] = alpha * in[tm_base +  49];
-          out[qphix_base + 26*VECLEN + x_internal] = alpha * in[tm_base +  50];
-          out[qphix_base + 27*VECLEN + x_internal] = alpha * in[tm_base +  51];
-          out[qphix_base + 28*VECLEN + x_internal] = alpha * in[tm_base +  52];
-          out[qphix_base + 29*VECLEN + x_internal] = alpha * in[tm_base +  53];
-          out[qphix_base + 30*VECLEN + x_internal] = alpha * in[tm_base +  74];
-          out[qphix_base + 31*VECLEN + x_internal] = alpha * in[tm_base +  75];
-          out[qphix_base + 32*VECLEN + x_internal] = alpha * in[tm_base +  76];
-          out[qphix_base + 33*VECLEN + x_internal] = alpha * in[tm_base +  77];
-          out[qphix_base + 34*VECLEN + x_internal] = alpha * in[tm_base +  82];
-          out[qphix_base + 35*VECLEN + x_internal] = alpha * in[tm_base +  83];
-          out[qphix_base + 36*VECLEN + x_internal] = alpha * in[tm_base +  18];
-          out[qphix_base + 37*VECLEN + x_internal] = alpha * in[tm_base +  26];
-          out[qphix_base + 38*VECLEN + x_internal] = alpha * in[tm_base +  34];
-          out[qphix_base + 39*VECLEN + x_internal] = alpha * in[tm_base +  90];
-          out[qphix_base + 40*VECLEN + x_internal] = alpha * in[tm_base +  98];
-          out[qphix_base + 41*VECLEN + x_internal] = alpha * in[tm_base + 106];
-          out[qphix_base + 42*VECLEN + x_internal] = alpha * in[tm_base +  20];
-          out[qphix_base + 43*VECLEN + x_internal] = alpha * in[tm_base +  21];
-          out[qphix_base + 44*VECLEN + x_internal] = alpha * in[tm_base +  22];
-          out[qphix_base + 45*VECLEN + x_internal] = alpha * in[tm_base +  23];
-          out[qphix_base + 46*VECLEN + x_internal] = alpha * in[tm_base +  54];
-          out[qphix_base + 47*VECLEN + x_internal] = alpha * in[tm_base +  55];
-          out[qphix_base + 48*VECLEN + x_internal] = alpha * in[tm_base +  56];
-          out[qphix_base + 49*VECLEN + x_internal] = alpha * in[tm_base +  57];
-          out[qphix_base + 50*VECLEN + x_internal] = alpha * in[tm_base +  58];
-          out[qphix_base + 51*VECLEN + x_internal] = alpha * in[tm_base +  59];
-          out[qphix_base + 52*VECLEN + x_internal] = alpha * in[tm_base +  28];
-          out[qphix_base + 53*VECLEN + x_internal] = alpha * in[tm_base +  29];
-          out[qphix_base + 54*VECLEN + x_internal] = alpha * in[tm_base +  60];
-          out[qphix_base + 55*VECLEN + x_internal] = alpha * in[tm_base +  61];
-          out[qphix_base + 56*VECLEN + x_internal] = alpha * in[tm_base +  62];
-          out[qphix_base + 57*VECLEN + x_internal] = alpha * in[tm_base +  63];
-          out[qphix_base + 58*VECLEN + x_internal] = alpha * in[tm_base +  64];
-          out[qphix_base + 59*VECLEN + x_internal] = alpha * in[tm_base +  65];
-          out[qphix_base + 60*VECLEN + x_internal] = alpha * in[tm_base +  66];
-          out[qphix_base + 61*VECLEN + x_internal] = alpha * in[tm_base +  67];
-          out[qphix_base + 62*VECLEN + x_internal] = alpha * in[tm_base +  68];
-          out[qphix_base + 63*VECLEN + x_internal] = alpha * in[tm_base +  69];
-          out[qphix_base + 64*VECLEN + x_internal] = alpha * in[tm_base +  70];
-          out[qphix_base + 65*VECLEN + x_internal] = alpha * in[tm_base +  71];
-          out[qphix_base + 66*VECLEN + x_internal] = alpha * in[tm_base +  92];
-          out[qphix_base + 67*VECLEN + x_internal] = alpha * in[tm_base +  93];
-          out[qphix_base + 68*VECLEN + x_internal] = alpha * in[tm_base +  94];
-          out[qphix_base + 69*VECLEN + x_internal] = alpha * in[tm_base +  95];
-          out[qphix_base + 70*VECLEN + x_internal] = alpha * in[tm_base + 100];
-          out[qphix_base + 71*VECLEN + x_internal] = alpha * in[tm_base + 101];
+          // FIXME Is there any better way to do that?
+          for (uint64_t lt_idx = 0; lt_idx < lookup_table.size(); ++lt_index) {
+            out[qphix_base + lt_idx * VECLEN + x_internal] =
+                alpha * in[tm_base + lookup_table[lt_idx]];
+          }
 
         }  // volume
 

--- a/qphix_interface.cpp
+++ b/qphix_interface.cpp
@@ -66,7 +66,9 @@ extern "C" {
 #include "solver/solver.h"
 #include "solver/solver_params.h"
 #include "solver/solver_field.h"
+#include "operator/clovertm_operators.h"
 #include "gettime.h"
+#include "geometry_eo.h"
 #include "update_backward_gauge.h"
 }
 #ifdef TM_USE_OMP
@@ -224,6 +226,140 @@ void _initQphix(int argc, char **argv, int By_, int Bz_, int NCores_, int Sy_, i
 // Finalize the QPhiX library
 void _endQphix() {}
 
+// Reorder the tmLQCD clover field to a Wilson QPhiX clover field
+template <typename FT, int VECLEN, int SOALEN, bool compress12>
+void reorder_clover_to_QPhiX(Geometry<FT, VECLEN, SOALEN, compress12> &geom, FT *qphix_clover) {
+  const double startTime = gettime();
+
+  // Need to rescale for QPhiX by alpha
+  const double alpha = 1.0 / ( 2.0 * g_kappa );
+
+  // Number of elements in spin, color & complex
+  const int Ns = 4;
+  const int Nc = 3;
+  const int Nz = 2;
+
+  // Geometric parameters for QPhiX data layout
+  const auto nyg = geom.nGY();
+  const auto nVecs = geom.nVecs();
+  const auto Pxy = geom.getPxy();
+  const auto Pxyz = geom.getPxyz();
+
+  // Get the base pointer for the (global) tmlQCD clover field
+  const double *in = reinterpret_cast<double*>(&sw[0][0][0].c00);
+
+  FT *out = qphix_clover;
+
+  // This will loop over the entire lattice and calculate
+  // the array and internal indices for both tmlQCD & QPhiX
+  for (uint64_t t = 0; t < T; t++)
+    for (uint64_t x = 0; x < LX; x++)
+      for (uint64_t y = 0; y < LY; y++)
+        for (uint64_t z = 0; z < LZ; z++) {
+
+          // Only copy the odd-odd elements of the clover term
+          if ((t + x + y + z) & 1 == 0) continue;
+
+          const uint64_t tm_idx = Index(t, x, y, z);
+
+          // These are the QPhiX SIMD vector in checkerboarded x direction
+          // (up to LX/2), the index inside one single Structure of Arrays (SOA)
+          // and the internal position inside the ("packed") SIMD vector
+          const uint64_t SIMD_vector = (x / 2) / SOALEN;
+          const uint64_t x_one_SOA = (x / 2) % SOALEN;
+          const uint64_t x_internal = (y % nyg) * SOALEN + x_one_SOA;
+
+          // Calculate the array index in QPhiX, given a global
+          // lattice index (t,x,y,z). This is also called the
+          // "block" in QPhiX and the QPhiX/QDP packers.
+          const uint64_t qphix_idx = (t * Pxyz + z * Pxy) / nyg + (y / nyg) * nVecs + SIMD_vector;
+
+          // Calculate the index where the tile for a given site begins
+          const uint64_t qphix_base = qphix_idx * VECLEN * 2 * ( 6 + 15 * Nz );
+          const uint64_t tm_base = tm_idx * 3 * 2 * Nc * Nc * Nz;
+
+          // FIXME:
+          // Is there any better way to do that?
+          // Use at least a lookup table
+          out[qphix_base +  0*VECLEN + x_internal] = alpha * in[tm_base +   0];
+          out[qphix_base +  1*VECLEN + x_internal] = alpha * in[tm_base +   8];
+          out[qphix_base +  2*VECLEN + x_internal] = alpha * in[tm_base +  16];
+          out[qphix_base +  3*VECLEN + x_internal] = alpha * in[tm_base +  72];
+          out[qphix_base +  4*VECLEN + x_internal] = alpha * in[tm_base +  80];
+          out[qphix_base +  5*VECLEN + x_internal] = alpha * in[tm_base +  88];
+          out[qphix_base +  6*VECLEN + x_internal] = alpha * in[tm_base +   2];
+          out[qphix_base +  7*VECLEN + x_internal] = alpha * in[tm_base +   3];
+          out[qphix_base +  8*VECLEN + x_internal] = alpha * in[tm_base +   4];
+          out[qphix_base +  9*VECLEN + x_internal] = alpha * in[tm_base +   5];
+          out[qphix_base + 10*VECLEN + x_internal] = alpha * in[tm_base +  36];
+          out[qphix_base + 11*VECLEN + x_internal] = alpha * in[tm_base +  37];
+          out[qphix_base + 12*VECLEN + x_internal] = alpha * in[tm_base +  38];
+          out[qphix_base + 13*VECLEN + x_internal] = alpha * in[tm_base +  39];
+          out[qphix_base + 14*VECLEN + x_internal] = alpha * in[tm_base +  40];
+          out[qphix_base + 15*VECLEN + x_internal] = alpha * in[tm_base +  41];
+          out[qphix_base + 16*VECLEN + x_internal] = alpha * in[tm_base +  10];
+          out[qphix_base + 17*VECLEN + x_internal] = alpha * in[tm_base +  11];
+          out[qphix_base + 18*VECLEN + x_internal] = alpha * in[tm_base +  42];
+          out[qphix_base + 19*VECLEN + x_internal] = alpha * in[tm_base +  43];
+          out[qphix_base + 20*VECLEN + x_internal] = alpha * in[tm_base +  44];
+          out[qphix_base + 21*VECLEN + x_internal] = alpha * in[tm_base +  45];
+          out[qphix_base + 22*VECLEN + x_internal] = alpha * in[tm_base +  46];
+          out[qphix_base + 23*VECLEN + x_internal] = alpha * in[tm_base +  47];
+          out[qphix_base + 24*VECLEN + x_internal] = alpha * in[tm_base +  48];
+          out[qphix_base + 25*VECLEN + x_internal] = alpha * in[tm_base +  49];
+          out[qphix_base + 26*VECLEN + x_internal] = alpha * in[tm_base +  50];
+          out[qphix_base + 27*VECLEN + x_internal] = alpha * in[tm_base +  51];
+          out[qphix_base + 28*VECLEN + x_internal] = alpha * in[tm_base +  52];
+          out[qphix_base + 29*VECLEN + x_internal] = alpha * in[tm_base +  53];
+          out[qphix_base + 30*VECLEN + x_internal] = alpha * in[tm_base +  74];
+          out[qphix_base + 31*VECLEN + x_internal] = alpha * in[tm_base +  75];
+          out[qphix_base + 32*VECLEN + x_internal] = alpha * in[tm_base +  76];
+          out[qphix_base + 33*VECLEN + x_internal] = alpha * in[tm_base +  77];
+          out[qphix_base + 34*VECLEN + x_internal] = alpha * in[tm_base +  82];
+          out[qphix_base + 35*VECLEN + x_internal] = alpha * in[tm_base +  83];
+          out[qphix_base + 36*VECLEN + x_internal] = alpha * in[tm_base +  18];
+          out[qphix_base + 37*VECLEN + x_internal] = alpha * in[tm_base +  26];
+          out[qphix_base + 38*VECLEN + x_internal] = alpha * in[tm_base +  34];
+          out[qphix_base + 39*VECLEN + x_internal] = alpha * in[tm_base +  90];
+          out[qphix_base + 40*VECLEN + x_internal] = alpha * in[tm_base +  98];
+          out[qphix_base + 41*VECLEN + x_internal] = alpha * in[tm_base + 106];
+          out[qphix_base + 42*VECLEN + x_internal] = alpha * in[tm_base +  20];
+          out[qphix_base + 43*VECLEN + x_internal] = alpha * in[tm_base +  21];
+          out[qphix_base + 44*VECLEN + x_internal] = alpha * in[tm_base +  22];
+          out[qphix_base + 45*VECLEN + x_internal] = alpha * in[tm_base +  23];
+          out[qphix_base + 46*VECLEN + x_internal] = alpha * in[tm_base +  54];
+          out[qphix_base + 47*VECLEN + x_internal] = alpha * in[tm_base +  55];
+          out[qphix_base + 48*VECLEN + x_internal] = alpha * in[tm_base +  56];
+          out[qphix_base + 49*VECLEN + x_internal] = alpha * in[tm_base +  57];
+          out[qphix_base + 50*VECLEN + x_internal] = alpha * in[tm_base +  58];
+          out[qphix_base + 51*VECLEN + x_internal] = alpha * in[tm_base +  59];
+          out[qphix_base + 52*VECLEN + x_internal] = alpha * in[tm_base +  28];
+          out[qphix_base + 53*VECLEN + x_internal] = alpha * in[tm_base +  29];
+          out[qphix_base + 54*VECLEN + x_internal] = alpha * in[tm_base +  60];
+          out[qphix_base + 55*VECLEN + x_internal] = alpha * in[tm_base +  61];
+          out[qphix_base + 56*VECLEN + x_internal] = alpha * in[tm_base +  62];
+          out[qphix_base + 57*VECLEN + x_internal] = alpha * in[tm_base +  63];
+          out[qphix_base + 58*VECLEN + x_internal] = alpha * in[tm_base +  64];
+          out[qphix_base + 59*VECLEN + x_internal] = alpha * in[tm_base +  65];
+          out[qphix_base + 60*VECLEN + x_internal] = alpha * in[tm_base +  66];
+          out[qphix_base + 61*VECLEN + x_internal] = alpha * in[tm_base +  67];
+          out[qphix_base + 62*VECLEN + x_internal] = alpha * in[tm_base +  68];
+          out[qphix_base + 63*VECLEN + x_internal] = alpha * in[tm_base +  69];
+          out[qphix_base + 64*VECLEN + x_internal] = alpha * in[tm_base +  70];
+          out[qphix_base + 65*VECLEN + x_internal] = alpha * in[tm_base +  71];
+          out[qphix_base + 66*VECLEN + x_internal] = alpha * in[tm_base +  92];
+          out[qphix_base + 67*VECLEN + x_internal] = alpha * in[tm_base +  93];
+          out[qphix_base + 68*VECLEN + x_internal] = alpha * in[tm_base +  94];
+          out[qphix_base + 69*VECLEN + x_internal] = alpha * in[tm_base +  95];
+          out[qphix_base + 70*VECLEN + x_internal] = alpha * in[tm_base + 100];
+          out[qphix_base + 71*VECLEN + x_internal] = alpha * in[tm_base + 101];
+
+        }  // volume
+
+  const double endTime = gettime();
+  const double diffTime = endTime - startTime;
+  masterPrintf("  time spent in reorder_clover_to_QPhiX: %f secs\n", diffTime);
+}
 
 // Reorder the tmLQCD gauge field to a cb0 and a cb1 QPhiX gauge field
 template <typename FT, int VECLEN, int SOALEN, bool compress12>


### PR DESCRIPTION
This is my first untested attempt at the helper functions for the solvers. It compiles with the `devel` version of QPhiX, where I have introduced RAII containers for the spinors. This way, one does not have to write dtors per hand, also the resource cleanup is much more C++ like now.

Documentation is added, please tell me if it is not precise enough. I'd like the code to explain itself.